### PR TITLE
Fix: SVG title id “more” unique

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -19,7 +19,7 @@ const accessiblize = function(str, name) {
     .attr("role", "img")
     .attr("class", `symbol symbol-${name}`);
 
-  svg("title").attr("id", "title").text(`${name} icon`);
+  svg("title").attr("id", `title-${name}`).text(`${name} icon`);
 
   svg("path").attr("role", "presentation");
 

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -15,7 +15,7 @@ const accessiblize = function(str, name) {
   const svg = cheerio.load(str, { xmlMode: true });
 
   svg("svg")
-    .attr("aria-labelledby", "title")
+    .attr("aria-labelledby", `title-${name}`)
     .attr("role", "img")
     .attr("class", `symbol symbol-${name}`);
 


### PR DESCRIPTION
## Problem
`aria-labelledby` refers to the `id` of `<title>`, and currently the `id` for all icons is `title`.

The value of `id` should be _more*_ unique.

## Fix
Append the name of the icon to the value of `id`.

### Before
```
<svg aria-labelledby="title">
  <title id="title">...
```
### After
```
<svg aria-labelledby="title-accounts-logo">
  <title id="title-accounts-logo">...
```

\* Caveat is that more than one of the same icon can be present on the same page.