### PR TITLE
Fix: SVG scaling proportionally

### DIFF
--- a/scripts/modules/build.mjs
+++ b/scripts/modules/build.mjs
@@ -55,7 +55,7 @@ function collectionSprite(collection) {
       });
 
       return `
-<symbol id="${symbol.name}" viewBox="${doc("svg").attr("viewBox")}">
+<symbol id="${symbol.name}" viewBox="${doc("svg").attr("viewBox")}" preserveAspectRatio="xMinYMin meet">
   ${cheerio.xml(doc("svg").children())}
 </symbol>`;
     })


### PR DESCRIPTION
## What
Aspect ratio of SVGs are not preserved when scaling—evident when sizing non-square icons, e.g. badges `apps#check-ins-badge`
![image](https://user-images.githubusercontent.com/359871/41749378-ac4f8576-757b-11e8-9828-062db5031afb.png)

## Solution
SVG must have attribute `preserveAspectRatio="xMinYMin meet"` to ensure the aspect ratio is respected.

Then `.symbol` must then be modified via `width: auto` because it assumes icons are squares (`width: 1em; height: 1em`)
```
<span style="font-size: 32px">
  <%= external_icon("apps#check-ins-badge", style: "width: auto") %>
</span>
```
![image](https://user-images.githubusercontent.com/359871/41749369-9f00df64-757b-11e8-93f9-50408e25a799.png)

Without `preserveAspectRatio="xMinYMin meet"`, the `viewBox` doesn’t get scaled proportionally; therefore the SVG becomes offset:
![image](https://user-images.githubusercontent.com/359871/41749434-eed00a24-757b-11e8-8825-e81f07c6bdeb.png)